### PR TITLE
Feature getvaluedescription

### DIFF
--- a/include/dbcppp/AttributeDefinition.h
+++ b/include/dbcppp/AttributeDefinition.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 #include <boost/variant.hpp>
-
+#include <functional>
 #include "Export.h"
 
 namespace dbcppp

--- a/include/dbcppp/EnvironmentVariable.h
+++ b/include/dbcppp/EnvironmentVariable.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 #include <cstddef>
-
+#include <functional>
 #include "Export.h"
 #include "Node.h"
 #include "Attribute.h"

--- a/include/dbcppp/Signal.h
+++ b/include/dbcppp/Signal.h
@@ -83,6 +83,7 @@ namespace dbcppp
         virtual bool hasReceiver(const std::string& name) const = 0;
         virtual void forEachReceiver(std::function<void(const std::string&)>&& cb) const = 0;
         virtual void forEachValueDescription(std::function<void(double, const std::string&)>&& cb) const = 0;
+        virtual const std::string* getValueDescription(double value) const = 0;
         virtual const Attribute* getAttributeValueByName(const std::string& name) const = 0;
         virtual const Attribute* findAttributeValue(std::function<bool(const Attribute&)>&& pred) const = 0;
         virtual const void forEachAttributeValue(std::function<void(const Attribute&)>&& cb) const = 0;

--- a/src/dbcppp/SignalImpl.cpp
+++ b/src/dbcppp/SignalImpl.cpp
@@ -580,6 +580,16 @@ void SignalImpl::forEachValueDescription(std::function<void(double, const std::s
         cb(av.first, av.second);
     }
 }
+const std::string* SignalImpl::getValueDescription(double value) const
+{
+    const std::string* result = nullptr;
+    auto iter = _value_descriptions.find(value);
+    if (iter != _value_descriptions.end())
+    {
+        result = &iter->second;
+    }
+    return result;
+}
 const Attribute* SignalImpl::getAttributeValueByName(const std::string& name) const
 {
     const Attribute* result = nullptr;

--- a/src/dbcppp/SignalImpl.h
+++ b/src/dbcppp/SignalImpl.h
@@ -51,6 +51,7 @@ namespace dbcppp
         virtual bool hasReceiver(const std::string& name) const override;
         virtual void forEachReceiver(std::function<void(const std::string&)>&& cb) const override;
         virtual void forEachValueDescription(std::function<void(double, const std::string&)>&& cb) const override;
+        virtual const std::string* getValueDescription(double value) const override;
         virtual const Attribute* getAttributeValueByName(const std::string& name) const override;
         virtual const Attribute* findAttributeValue(std::function<bool(const Attribute&)>&& pred) const override;
         virtual const void forEachAttributeValue(std::function<void(const Attribute&)>&& cb) const override;


### PR DESCRIPTION
adding feature to get value a description literal when a signal has an associated value description.

In my environment, absence of functional header causes compile errors.