### PR TITLE
cmake package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ target_sources("libxmlmm"
 )
 
 install(
-    TARGETS "libxmlmm"
+    TARGETS "libxmlmm" "LibXml2" EXPORT ${PROJECT_NAME}Targets
     DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(
     DIRECTORY "libxmlmm"

--- a/src/libdbcppp/CMakeLists.txt
+++ b/src/libdbcppp/CMakeLists.txt
@@ -34,19 +34,52 @@ file(GLOB src
 
 target_sources(${PROJECT_NAME}
     PRIVATE ${header} 
-    PUBLIC ${header_interface}
+    PRIVATE ${header_interface}
     PRIVATE ${src} DBCX3AdaptStructs.inl
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${header_interface}")
 
 include(GenerateExportHeader)
 generate_export_header(${PROJECT_NAME})
 
 # install
 install(
-    TARGETS ${PROJECT_NAME}
-    DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dbcppp)
 install(
     FILES
-		$<TARGET_PROPERTY:${PROJECT_NAME},INTERFACE_SOURCES>
+    $<TARGET_PROPERTY:${PROJECT_NAME},INTERFACE_SOURCES>
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dbcppp)
 	
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION ${Upstream_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
+export(EXPORT ${PROJECT_NAME}Targets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Targets.cmake"
+)
+configure_file(cmake/${PROJECT_NAME}Config.cmake
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+  @ONLY
+)
+
+set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
+install(EXPORT ${PROJECT_NAME}Targets
+  FILE
+    ${PROJECT_NAME}Targets.cmake
+  DESTINATION
+    ${ConfigPackageLocation}
+)
+install(
+  FILES
+    cmake/${PROJECT_NAME}Config.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION
+    ${ConfigPackageLocation}
+  COMPONENT
+    Devel
+)

--- a/src/libdbcppp/cmake/libdbcpppConfig.cmake
+++ b/src/libdbcppp/cmake/libdbcpppConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/libdbcpppTargets.cmake")


### PR DESCRIPTION
Addressing the point raised in #92 about making package cmake config so that a user can use `find_package()` directive. For instance:
```cmake
find_package(libdbcppp REQUIRED)
...
target_link_libraries(PROJECT libdbcppp)
```
This makes it nice & clear, plus independent of the install directory.

I had to make absolute header file paths PRIVATE here:
https://github.com/simutisernestas/dbcppp/blob/90ea83390f6a6715505be920c667a43a16a537b5/src/libdbcppp/CMakeLists.txt#L37
I don't fully get it why `cmake` complains about it, but a work around I found on SO exposes them as `PUBLIC_HEADER`. It works but at the same time there probably are more elegant solutions available.