### PR TITLE
Adds a few cmake fixes to improve package discovery.

### DIFF
--- a/src/libdbcppp/CMakeLists.txt
+++ b/src/libdbcppp/CMakeLists.txt
@@ -14,6 +14,12 @@ include_directories(
     ${CMAKE_BINARY_DIR}/src
 )
 
+target_include_directories(
+	  ${PROJECT_NAME}
+	  PUBLIC
+	  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/>
+)
+
 test_big_endian(is_big_endian)
 if (is_big_endian)
     set(BYTE_ORDER Big)
@@ -67,7 +73,7 @@ configure_file(cmake/${PROJECT_NAME}Config.cmake
   @ONLY
 )
 
-set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 install(EXPORT ${PROJECT_NAME}Targets
   FILE
     ${PROJECT_NAME}Targets.cmake


### PR DESCRIPTION
- Adds target_include_directories to properly discover header files when using an external target.
- Replaces "lib" by "CMAKE_INSTALL_LIBDIR" when setting "ConfigPackageLocation"

See https://github.com/xR3b0rn/dbcppp/issues/96 for context.