### PR TITLE
Fix a typo in FreeBSD support

### DIFF
--- a/src/libdbcppp/Helper.h
+++ b/src/libdbcppp/Helper.h
@@ -24,7 +24,7 @@
 #elif defined(__FreeBSD__)
 #   include <sys/endian.h>
 #   define bswap_32(x) bswap32(x)
-#   defiee bswap_64(x) bswap64(x)
+#   define bswap_64(x) bswap64(x)
 #elif defined(__OpenBSD__)
 #   include <sys/types.h>
 #   define bswap_32(x) swap32(x)


### PR DESCRIPTION
With this change, builds work on FreeBSD and RunTests finishes successfully with:
```
All tests passed (10243 assertions in 7 test cases)
```