### PR TITLE
Fix includes for GCC 14

### DIFF
--- a/src/AttributeDefinitionImpl.cpp
+++ b/src/AttributeDefinitionImpl.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include "AttributeDefinitionImpl.h"
 

--- a/src/EnvironmentVariableImpl.cpp
+++ b/src/EnvironmentVariableImpl.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "EnvironmentVariableImpl.h"
 
 using namespace dbcppp;

--- a/src/MessageImpl.cpp
+++ b/src/MessageImpl.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "MessageImpl.h"
 
 using namespace dbcppp;

--- a/src/NetworkImpl.cpp
+++ b/src/NetworkImpl.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <fstream>
 #include <iomanip>
 #include "dbcppp/Network.h"

--- a/src/NodeImpl.cpp
+++ b/src/NodeImpl.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "NodeImpl.h"
 
 using namespace dbcppp;

--- a/src/SignalGroupImpl.cpp
+++ b/src/SignalGroupImpl.cpp
@@ -1,4 +1,4 @@
-
+#include <algorithm>
 #include "SignalGroupImpl.h"
 
 using namespace dbcppp;

--- a/src/SignalImpl.cpp
+++ b/src/SignalImpl.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <limits>
 #include "Helper.h"
 #include "SignalImpl.h"

--- a/src/SignalMultiplexerValueImpl.cpp
+++ b/src/SignalMultiplexerValueImpl.cpp
@@ -1,4 +1,4 @@
-
+#include <algorithm>
 #include "SignalMultiplexerValueImpl.h"
 
 using namespace dbcppp;

--- a/src/ValueTableImpl.cpp
+++ b/src/ValueTableImpl.cpp
@@ -1,4 +1,4 @@
-
+#include <algorithm>
 #include "dbcppp/Network.h"
 #include "ValueTableImpl.h"
 


### PR DESCRIPTION
Build fails with GCC 14.
I guess that they removed transitive includes which broke the dbcppp build.
This PR adds `#include <algorithm>` where `std::find` is used, which is the 'official' header to use for `std::find`.