### PR TITLE
APITests: Store string literals in const char* to fix GCC warnings

### DIFF
--- a/tests/APITests.cpp
+++ b/tests/APITests.cpp
@@ -7,7 +7,7 @@ using namespace dbcppp;
 
 TEST_CASE("API Test: AttributeDefinition", "[]")
 {
-    constexpr char* test_dbc =
+    constexpr const char* test_dbc =
         "VERSION \"\"\n"
         "NS_ :\n"
         "BS_:\n"
@@ -44,7 +44,7 @@ TEST_CASE("API Test: AttributeDefinition", "[]")
 }
 TEST_CASE("API Test: BitTiming", "[]")
 {
-    constexpr char* test_dbc =
+    constexpr const char* test_dbc =
         "VERSION \"\"\n"
         "NS_ :\n"
         "BS_: 1 : 2, 3\n"
@@ -74,7 +74,7 @@ TEST_CASE("API Test: BitTiming", "[]")
 }
 TEST_CASE("API Test: EnvironmentVariable", "[]")
 {
-    constexpr char* test_dbc =
+    constexpr const char* test_dbc =
         "VERSION \"\"\n"
         "NS_ :\n"
         "BS_:\n"
@@ -122,7 +122,7 @@ TEST_CASE("API Test: EnvironmentVariable", "[]")
 }
 TEST_CASE("API Test: Signal", "[]")
 {
-    constexpr char* test_dbc =
+    constexpr const char* test_dbc =
         "VERSION \"\"\n"
         "NS_ :\n"
         "BS_: 1 : 2, 3\n"
@@ -211,7 +211,7 @@ TEST_CASE("API Test: Signal", "[]")
 }
 TEST_CASE("API Test: Message", "[]")
 {
-    constexpr char* test_dbc =
+    constexpr const char* test_dbc =
         "VERSION \"\"\n"
         "NS_ :\n"
         "BS_: 1 : 2, 3\n"


### PR DESCRIPTION
GCC 13 and 14 emit some warnings from API tests due to storing string literals in a mutable char pointer. (-Wwrite-strings)
AFAIK `constexpr` used to imply `const`, which is not the case any more in recent C++ standards.
This PR adds an explicit `const` to variables initialized by a string literal.