### PR TITLE
add includes for uint*_t types which are missing in fedora

### DIFF
--- a/include/dbcppp/Node.h
+++ b/include/dbcppp/Node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <functional>
+#include <cstdint>
 
 #include "Export.h"
 #include "Iterator.h"

--- a/include/dbcppp/SignalGroup.h
+++ b/include/dbcppp/SignalGroup.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <memory>
 #include <functional>
+#include <cstdint>
 
 #include "Export.h"
 #include "Iterator.h"

--- a/include/dbcppp/SignalMultiplexerValue.h
+++ b/include/dbcppp/SignalMultiplexerValue.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 #include <functional>
+#include <cstdint>
 
 #include "Iterator.h"
 

--- a/src/Helper.h
+++ b/src/Helper.h
@@ -40,6 +40,8 @@
 #   include <byteswap.h>
 #endif
 
+#include <cstdint>
+
 namespace dbcppp
 {
     class NodeImpl;


### PR DESCRIPTION
Hello, unfortunately the library does not compile under fedora because includes of `cstdint` which provides `uint64_t` is required.

With this PR you can build it with `-Dbuild_kcd=OFF Dbuild_examples=OFF Dbuild_tools=OFF` under fedora. Tests are passing.