### PR TITLE
Advanced multiplexing

### DIFF
--- a/include/dbcppp/Iterator.h
+++ b/include/dbcppp/Iterator.h
@@ -28,10 +28,31 @@ namespace dbcppp
         {
             return &(_parent->*_get)(_i);
         }
+        inline reference operator[](std::size_t o) const
+        {
+            return *(*this + o);
+        }
         constexpr self_t& operator++() noexcept
         {
-            _i++;
+            ++_i;
             return *this;
+        }
+        constexpr self_t& operator--() noexcept
+        {
+            --_i;
+            return *this;
+        }
+        constexpr self_t operator++(int) noexcept
+        {
+            self_t old = *this;
+            ++_i;
+            return std::move(old);
+        }
+        constexpr self_t operator--(int) noexcept
+        {
+            self_t old = *this;
+            --_i;
+            return std::move(old);
         }
         constexpr self_t operator+(std::size_t o) const noexcept
         {
@@ -64,6 +85,22 @@ namespace dbcppp
         {
             return !(*this == rhs);
         }
+        constexpr bool operator<(const self_t& rhs) const noexcept
+        {
+            return _i < rhs._i;
+        }
+        constexpr bool operator>(const self_t& rhs) const noexcept
+        {
+            return _i > rhs._i;
+        }
+        constexpr bool operator<=(const self_t& rhs) const noexcept
+        {
+            return _i <= rhs._i;
+        }
+        constexpr bool operator>=(const self_t& rhs) const noexcept
+        {
+            return _i >= rhs._i;
+        }
 
     private:
         P _parent;
@@ -87,6 +124,10 @@ namespace dbcppp
             , _get(std::move(get))
             , _size(std::move(size))
         {}
+        inline reference operator[](std::size_t o) const
+        {
+            return (_parent->*_get)(o);
+        }
         constexpr iterator begin() noexcept
         {
             return iterator(_parent, _get, 0);
@@ -95,13 +136,29 @@ namespace dbcppp
         {
             return iterator(_parent, _get, _size);
         }
-        constexpr const_iterator begin() const noexcept
+        constexpr const_iterator cbegin() const noexcept
         {
             return const_iterator(_parent, _get, 0);
         }
-        constexpr const_iterator end() const noexcept
+        constexpr const_iterator cend() const noexcept
         {
             return const_iterator(_parent, _get, _size);
+        }
+        constexpr const_iterator begin() const noexcept
+        {
+            return cbegin();
+        }
+        constexpr const_iterator end() const noexcept
+        {
+            return cend();
+        }
+        constexpr size_type size() const noexcept
+        {
+            return _size;
+        }
+        constexpr bool empty() const noexcept
+        {
+            return _size == 0;
         }
 
     private:

--- a/include/dbcppp/Iterator.h
+++ b/include/dbcppp/Iterator.h
@@ -15,20 +15,20 @@ namespace dbcppp
         using pointer           = value_type*;
         using reference         = value_type&;
 
-        constexpr Iterator(P parent, F get, std::size_t i) noexcept
+        constexpr Iterator(P parent, F get, difference_type i) noexcept
             : _parent(parent)
             , _get(std::move(get))
             , _i(i)
         {}
         inline reference operator*() const
         {
-            return (_parent->*_get)(_i);
+            return (_parent->*_get)(static_cast<size_t>(_i));
         }
         inline pointer operator->() const
         {
-            return &(_parent->*_get)(_i);
+            return &(_parent->*_get)(static_cast<size_t>(_i));
         }
-        inline reference operator[](std::size_t o) const
+        inline reference operator[](difference_type o) const
         {
             return *(*this + o);
         }
@@ -54,11 +54,11 @@ namespace dbcppp
             --_i;
             return std::move(old);
         }
-        constexpr self_t operator+(std::size_t o) const noexcept
+        constexpr self_t operator+(difference_type o) const noexcept
         {
             return {_parent, _get, _i + o};
         }
-        constexpr self_t operator-(std::size_t o) const noexcept
+        constexpr self_t operator-(difference_type o) const noexcept
         {
             return {_parent, _get, _i - o};
         }
@@ -66,12 +66,12 @@ namespace dbcppp
         {
             return _i - rhs._i;
         }
-        constexpr self_t& operator+=(std::size_t o) noexcept
+        constexpr self_t& operator+=(difference_type o) noexcept
         {
             _i += o;
             return *this;
         }
-        constexpr self_t& operator-=(std::size_t o) noexcept
+        constexpr self_t& operator-=(difference_type o) noexcept
         {
             _i -= o;
             return *this;
@@ -105,7 +105,7 @@ namespace dbcppp
     private:
         P _parent;
         F _get;
-        std::size_t _i;
+        difference_type _i;
     };
     template<class T, class P, typename F>
     class Iterable final
@@ -142,7 +142,7 @@ namespace dbcppp
         }
         constexpr const_iterator cend() const noexcept
         {
-            return const_iterator(_parent, _get, _size);
+            return const_iterator(_parent, _get, static_cast<difference_type>(_size));
         }
         constexpr const_iterator begin() const noexcept
         {

--- a/include/dbcppp/Iterator.h
+++ b/include/dbcppp/Iterator.h
@@ -1,8 +1,6 @@
-
 #pragma once
 
-#include <functional>
-#include <optional>
+#include <iterator>
 
 namespace dbcppp
 {

--- a/include/dbcppp/Message.h
+++ b/include/dbcppp/Message.h
@@ -50,6 +50,9 @@ namespace dbcppp
         virtual const std::string& Comment() const = 0;
         virtual const ISignalGroup& SignalGroups_Get(std::size_t i) const = 0;
         virtual uint64_t SignalGroups_Size() const = 0;
+        /// \brief Optional multiplexor signal when this message is using simple multiplexing with a single switch.
+        ///
+        /// For advanced multiplexing support, ISignal::SignalMultiplexerValues needs to be followed instead.
         virtual const ISignal* MuxSignal() const = 0;
         
         DBCPPP_MAKE_ITERABLE(IMessage, MessageTransmitters, std::string);

--- a/include/dbcppp/Signal.h
+++ b/include/dbcppp/Signal.h
@@ -25,8 +25,7 @@ namespace dbcppp
             MaschinesFloatEncodingNotSupported = 1,
             MaschinesDoubleEncodingNotSupported = 2,
             SignalExceedsMessageSize = 4,
-            WrongBitSizeForExtendedDataType = 8,
-            ConflictingMultiplexDefinition = 16,
+            WrongBitSizeForExtendedDataType = 8
         };
         enum class EMultiplexer
         {
@@ -136,11 +135,11 @@ namespace dbcppp
         DBCPPP_MAKE_ITERABLE(ISignal, ValueEncodingDescriptions, IValueEncodingDescription);
         DBCPPP_MAKE_ITERABLE(ISignal, AttributeValues, IAttribute);
 
-        /// \brief Mapping of this multiplexed signal to specific value ranges of a selected multiplexor switch signal.
+        /// \brief Mapping of this multiplexed signal to specific value ranges of a selected multiplexor switch signals.
         /// 
-        /// In a valid DBC, this can only have 0 or 1 entries.
         /// Requires EMultiplexer::MuxValue to be set in MultiplexerIndicator in order to be valid.
         /// If empty, simple multiplexing rules by ISignal::MultiplexerSwitchValue and IMessage::MuxSignal apply instead.
+        /// If not empty, all listed multiplexor signals must match the specified value ranges simultaniously.
         DBCPPP_MAKE_ITERABLE(ISignal, SignalMultiplexerValues, ISignalMultiplexerValue);
 
     protected:

--- a/include/dbcppp/SignalMultiplexerValue.h
+++ b/include/dbcppp/SignalMultiplexerValue.h
@@ -6,12 +6,12 @@
 #include <memory>
 #include <vector>
 #include <functional>
-#include <cstdint>
 
 #include "Iterator.h"
 
 namespace dbcppp
 {
+    // Map from values of the multiplexor signal ISignalMultiplexerValue::SwitchName to the parent multiplexed ISignal.
     class ISignalMultiplexerValue
     {
     public:

--- a/src/DBCAST2Network.cpp
+++ b/src/DBCAST2Network.cpp
@@ -351,16 +351,20 @@ static auto getSignals(const G_Network& gnet, const G_Message& m, Cache const& c
         uint64_t multiplexer_switch_value = 0;
         if (s.multiplexer_indicator)
         {
-            auto m = *s.multiplexer_indicator;
-            if (m.substr(0, 1) == "M")
+            const auto& m = *s.multiplexer_indicator;
+            if (auto mux_value_pos = m.find('m', 0); mux_value_pos != std::string::npos)
             {
-                multiplexer_indicator = ISignal::EMultiplexer::MuxSwitch;
+                multiplexer_indicator = ISignal::EMultiplexer(
+                    std::underlying_type_t<ISignal::EMultiplexer>(multiplexer_indicator) |
+                    std::underlying_type_t<ISignal::EMultiplexer>(ISignal::EMultiplexer::MuxValue));
+                multiplexer_switch_value = std::atoi(m.c_str() + mux_value_pos + 1);
             }
-            else
+            if (m.find('M', 0) != std::string::npos)
             {
-                multiplexer_indicator = ISignal::EMultiplexer::MuxValue;
-                std::string value = m.substr(1, m.size());
-                multiplexer_switch_value = std::atoi(value.c_str());
+                multiplexer_indicator =
+                    ISignal::EMultiplexer(
+                        std::underlying_type_t<ISignal::EMultiplexer>(multiplexer_indicator) |
+                        std::underlying_type_t<ISignal::EMultiplexer>(ISignal::EMultiplexer::MuxSwitch));
             }
         }
 

--- a/src/Network2DBC.cpp
+++ b/src/Network2DBC.cpp
@@ -499,10 +499,19 @@ DBCPPP_API std::ostream& dbcppp::Network2DBC::operator<<(std::ostream& os, const
 DBCPPP_API std::ostream& dbcppp::Network2DBC::operator<<(std::ostream& os, const ISignal& s)
 {
     os << "\tSG_ " << s.Name() << " ";
-    switch (s.MultiplexerIndicator())
+    if (s.MultiplexerIndicator() != ISignal::EMultiplexer::NoMux)
     {
-    case ISignal::EMultiplexer::MuxSwitch: os << "M "; break;
-    case ISignal::EMultiplexer::MuxValue: os << "m" << s.MultiplexerSwitchValue() << " "; break;
+        if (std::underlying_type_t<ISignal::EMultiplexer>(s.MultiplexerIndicator()) &
+            std::underlying_type_t<ISignal::EMultiplexer>(ISignal::EMultiplexer::MuxValue))
+        {
+            os << "m" << s.MultiplexerSwitchValue();
+        }
+        if (std::underlying_type_t<ISignal::EMultiplexer>(s.MultiplexerIndicator()) &
+            std::underlying_type_t<ISignal::EMultiplexer>(ISignal::EMultiplexer::MuxSwitch))
+        {
+            os << "M";
+        }
+        os << " ";
     }
     os << ": " << s.StartBit() << "|" << s.BitSize() << "@";
     switch (s.ByteOrder())

--- a/src/SignalImpl.cpp
+++ b/src/SignalImpl.cpp
@@ -517,22 +517,6 @@ SignalImpl::SignalImpl(
         _phys_to_raw = ::phys_to_raw<double>;
         break;
     }
-    // Permitted due to faulty interface design in ISignal only - doesn't happen with real DBC files.
-    if (_signal_multiplexer_values.size() > 1)
-    {
-        SetError(EErrorCode::ConflictingMultiplexDefinition);
-    }
-    else if (_signal_multiplexer_values.size() == 1)
-    {
-        const auto ranges = _signal_multiplexer_values[0].ValueRanges();
-        if (!std::any_of(std::begin(ranges), std::end(ranges), [&](const ISignalMultiplexerValue::Range& range) -> bool
-            {
-                return range.from <= _multiplexer_switch_value && range.to >= _multiplexer_switch_value;
-            }))
-        {
-            SetError(EErrorCode::ConflictingMultiplexDefinition);
-        }
-    }
 }
 std::unique_ptr<ISignal> SignalImpl::Clone() const
 {


### PR DESCRIPTION
Resolves https://github.com/xR3b0rn/dbcppp/issues/84, eliminates costly heap-allocated binder objects and generally ensures compatibility with C++ named requirements for containers and iterators.

Resolves https://github.com/xR3b0rn/dbcppp/issues/166 - specifically correcting the serialization / deserialization of `multiplexer_indicator`, and adding validation for the the edge cases you can run into when not knowing the difference between simple and "advanced" multiplexing in DBC.

No externally visible ABI (at least not on exported symbols for shared library) or API changes,